### PR TITLE
fix: bottom dialog close by swipe error

### DIFF
--- a/odyssey/odyssey-compose/src/commonMain/kotlin/ru/alexgladkov/odyssey/compose/navigation/modal_navigation/views/BottomSheetModalView.kt
+++ b/odyssey/odyssey-compose/src/commonMain/kotlin/ru/alexgladkov/odyssey/compose/navigation/modal_navigation/views/BottomSheetModalView.kt
@@ -64,7 +64,7 @@ internal fun BoxScope.BottomModalSheet(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        if (bundle.closeOnSwipe){
+        if (bundle.closeOnSwipe) {
             modifier = modifier.swipeable(
                 state = swipeableState,
                 anchors = anchors,
@@ -89,7 +89,7 @@ internal fun BoxScope.BottomModalSheet(
     }
 
     LaunchedEffect(bundle.dialogState, swipeableState.offset.value) {
-        if (swipeableState.offset.value == viewHeight) {
+        if (swipeableState.offset.value == viewHeight && bundle.dialogState !is ModalDialogState.Close) {
             modalController.setTopDialogState(ModalDialogState.Close())
         }
 


### PR DESCRIPTION
when closing the BottomSheetDialog by swiping, the method is called several times
`modalController.setTopDialogState(ModalDialogState.Close())`
which causes multiple `_backStack.last` with a closed state, which eventually results in an error.