### PR TITLE
fix: dialog close by screamer double click error

### DIFF
--- a/odyssey/odyssey-compose/src/commonMain/kotlin/ru/alexgladkov/odyssey/compose/navigation/modal_navigation/views/BottomSheetModalView.kt
+++ b/odyssey/odyssey-compose/src/commonMain/kotlin/ru/alexgladkov/odyssey/compose/navigation/modal_navigation/views/BottomSheetModalView.kt
@@ -57,7 +57,7 @@ internal fun BoxScope.BottomModalSheet(
         bundle.backContent.invoke()
     } else {
         Screamer(backdropAlpha) {
-            if (bundle.closeOnBackdropClick) {
+            if (bundle.closeOnBackdropClick && bundle.dialogState !is ModalDialogState.Close) {
                 modalController.popBackStack()
             }
         }


### PR DESCRIPTION
при двойном клике на скример во время анимации закрытия падает ошибка:

ru.alexgladkov.odyssey.compose.controllers.ModalController.setTopDialogState$odyssey_compose_debug (ModalRootController.kt:206)
ru.alexgladkov.odyssey.compose.controllers.ModalController.popBackStack (ModalRootController.kt:126)
ru.alexgladkov.odyssey.compose.controllers.ModalController.popBackStack$default (ModalRootController.kt:125)
ru.alexgladkov.odyssey.compose.navigation.modal_navigation.views.BottomSheetModalViewKt$BottomModalSheet$1.invoke (BottomSheetModalView.kt:61)
ru.alexgladkov.odyssey.compose.navigation.modal_navigation.views.BottomSheetModalViewKt$BottomModalSheet$1.invoke (BottomSheetModalView.kt:59)
ru.alexgladkov.odyssey.compose.navigation.modal_navigation.ModalNavigatorKt$Screamer$$inlined$noRippleClickable$1$1.invoke (NoRippleClickable.kt:17)
ru.alexgladkov.odyssey.compose.navigation.modal_navigation.ModalNavigatorKt$Screamer$$inlined$noRippleClickable$1$1.invoke (NoRippleClickable.kt:12)