### PR TITLE
Bugfix/fix modal screen height

### DIFF
--- a/buildSrc/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Dependencies {
 
-    val odyssey = "1.0.0-beta11"
+    val odyssey = "1.0.0-beta12"
     val odysseyPackage = "io.github.alexgladkov"
 
     object DI {

--- a/documentation/GETTING_STARTED.md
+++ b/documentation/GETTING_STARTED.md
@@ -4,8 +4,8 @@ Add dependencies to gradle
 ```kotlin
 named("commonMain") {
     dependencies {
-        implementation("io.github.alexgladkov:odyssey-core:1.0.0-beta11") // For core classes
-        implementation("io.github.alexgladkov:odyssey-compose:1.0.0-beta11") // For compose extensions
+        implementation("io.github.alexgladkov:odyssey-core:1.0.0-beta12") // For core classes
+        implementation("io.github.alexgladkov:odyssey-compose:1.0.0-beta12") // For compose extensions
     }
 }
 ```

--- a/odyssey/odyssey-compose/src/commonMain/kotlin/ru/alexgladkov/odyssey/compose/navigation/modal_navigation/views/BottomSheetModalView.kt
+++ b/odyssey/odyssey-compose/src/commonMain/kotlin/ru/alexgladkov/odyssey/compose/navigation/modal_navigation/views/BottomSheetModalView.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import ru.alexgladkov.odyssey.compose.controllers.ModalController
@@ -30,8 +31,13 @@ internal fun BoxScope.BottomModalSheet(
 
     var modifier = Modifier.align(Alignment.BottomStart).fillMaxWidth()
 
+    val density = LocalDensity.current
+
+
     if (bundle.maxHeight != null)
-        modifier = modifier.fillMaxHeight(bundle.maxHeight)
+        modifier = modifier
+            .padding(top = with(density) { (height - viewHeight).toDp() })
+            .fillMaxHeight()
 
     var offsetValue by remember { mutableStateOf(height) }
     var backdropAlphaValue by remember { mutableStateOf(0f) }


### PR DESCRIPTION
fix bottom sheet height with keyboard and without

before fix:
![before_fix](https://user-images.githubusercontent.com/1107015/175509811-026debf4-d291-4d89-8ba4-242ee445b095.gif)

after fix:
![after_fix](https://user-images.githubusercontent.com/1107015/175509848-10d08ea1-82a4-4b41-bf47-4810f3c48bae.gif)

