### PR TITLE
Added callback for getting breadcrumbs from navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ feel free to open new issue in Issues section
 [<img src="screenshots/android-screen-favorite.png" width="250" height = "551" />](screenshots/android-screen-favorite.png)
 [<img src="screenshots/desktop-screen-favorite.png" width="500" height = "375" />](screenshots/desktop-screen-favorite.png)
 
+### Building and publishing locally
+
+The project doesn't require any additional setup to be modified and consumed locally. To publish the library with your 
+modifications to your local Maven repository, run the following command:
+
+```sh
+./gradlew publishToMavenLocal -Psigning.skip
+```
+
+Don't forget to either put `mavenLocal()` higher in `repositories` block or increase library version. This way your 
+local modifications would be prioritized over official version from Maven Central repository.
+
 ### License
 ```
 MIT License

--- a/android/src/main/java/ru/alexgladkov/odyssey_demo/MainActivity.kt
+++ b/android/src/main/java/ru/alexgladkov/odyssey_demo/MainActivity.kt
@@ -1,34 +1,49 @@
 package ru.alexgladkov.odyssey_demo
 
-import android.os.Build
 import android.os.Bundle
-import android.view.WindowInsets
-import android.view.WindowInsetsController
-import android.view.WindowManager
-import androidx.activity.compose.setContent
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.material.Text
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.core.view.WindowCompat
+import kotlinx.coroutines.CoroutineScope
 import ru.alexgladkov.common.compose.NavigationTree
-import ru.alexgladkov.common.compose.navigation.customNavScreen
-import ru.alexgladkov.common.compose.navigation.mainScreen
 import ru.alexgladkov.common.compose.navigation.navigationGraph
-import ru.alexgladkov.common.compose.navigation.topNavScreen
-import ru.alexgladkov.common.compose.screens.ActionsScreen
-import ru.alexgladkov.common.compose.screens.PresentedActionsScreen
-import ru.alexgladkov.odyssey.compose.extensions.flow
-import ru.alexgladkov.odyssey.compose.extensions.screen
+import ru.alexgladkov.odyssey.compose.RootController
 import ru.alexgladkov.odyssey_demo.theme.setupThemedNavigation
 
 class MainActivity : AppCompatActivity() {
 
-    @OptIn(ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setupThemedNavigation(NavigationTree.Actions.name) { navigationGraph() }
     }
+}
+
+fun RootController.setupAnalytics(coroutineScope: CoroutineScope) {
+    onBreadcrumb = {
+        val realKey = when {
+            it.startsWith(RootController.multiStackKey) -> it.substringAfter(RootController.multiStackKey + "$") // started multistack
+            else -> it
+        }
+        Log.d("NAVI", "onBreadcrumb [$realKey]")
+        //Log.d("NAVI", "onBreadcrumb [$realKey]", Exception())
+    }
+    /*coroutineScope.launch {
+        currentScreen.filterNotNull().collect { nav ->
+            Log.d("NAVI", "transition [${nav.screenToRemove?.realKey}] -> [${nav.screen.realKey}]")
+        }
+    }*/
+    /*coroutineScope.launch {
+        var prev = listOf<ModalBundle>()
+        findModalController().currentStack.distinctUntilChanged().collect { curr ->
+            if (prev.size >= curr.size && prev.isNotEmpty()) {
+                Log.d("NAVI", "pop modal")
+            }
+            if (prev.size <= curr.size && curr.isNotEmpty()) {
+                val stack = curr.joinToString { it.key }
+                Log.d("NAVI", "push modal [$stack]")
+                //Log.d("NAVI", "push modal [${curr.lastOrNull()?.key}]")
+            }
+        }
+    }*/
 }

--- a/android/src/main/java/ru/alexgladkov/odyssey_demo/theme/Activity + Setup.kt
+++ b/android/src/main/java/ru/alexgladkov/odyssey_demo/theme/Activity + Setup.kt
@@ -9,27 +9,35 @@ import androidx.compose.runtime.ProvidedValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
 import ru.alexgladkov.common.compose.theme.Odyssey
 import ru.alexgladkov.common.compose.theme.OdysseyTheme
+import ru.alexgladkov.odyssey.compose.RootController
 import ru.alexgladkov.odyssey.compose.base.Navigator
 import ru.alexgladkov.odyssey.compose.extensions.setupWithActivity
 import ru.alexgladkov.odyssey.compose.local.LocalRootController
 import ru.alexgladkov.odyssey.compose.navigation.RootComposeBuilder
 import ru.alexgladkov.odyssey.compose.navigation.modal_navigation.ModalNavigator
 import ru.alexgladkov.odyssey.compose.navigation.modal_navigation.configuration.DefaultModalConfiguration
+import ru.alexgladkov.odyssey_demo.setupAnalytics
 
 fun ComponentActivity.setupThemedNavigation(
     startScreen: String,
     vararg providers: ProvidedValue<*>,
     navigationGraph: RootComposeBuilder.() -> Unit
-) {
+) : RootController {
+    val rootController = RootComposeBuilder()
+        .apply(navigationGraph)
+        .build()
+        .apply {
+            setupWithActivity(this@setupThemedNavigation)
+            setupAnalytics(lifecycleScope)
+        }
+
     setContent {
         OdysseyTheme {
             val backgroundColor = Odyssey.color.primaryBackground
-            val rootController = RootComposeBuilder()
-                .apply(navigationGraph).build()
             rootController.backgroundColor = backgroundColor
-            rootController.setupWithActivity(this)
 
             CompositionLocalProvider(
                 *providers,
@@ -41,4 +49,6 @@ fun ComponentActivity.setupThemedNavigation(
             }
         }
     }
+
+    return rootController
 }

--- a/buildSrc/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Dependencies {
 
-    val odyssey = "1.2.0"
+    val odyssey = "1.2.1-SNAPSHOT"
     val odysseyPackage = "io.github.alexgladkov"
 
     val compileSdk = 33

--- a/buildSrc/src/main/kotlin/convention.publication.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.publication.gradle.kts
@@ -88,5 +88,6 @@ publishing {
 
 // Signing artifacts. Signing.* extra properties values will be used
 signing {
+    setRequired { !hasProperty("signing.skip") }
     sign(publishing.publications)
 }

--- a/odyssey/odyssey-compose/src/commonMain/kotlin/ru/alexgladkov/odyssey/compose/controllers/MultiStackRootController.kt
+++ b/odyssey/odyssey-compose/src/commonMain/kotlin/ru/alexgladkov/odyssey/compose/controllers/MultiStackRootController.kt
@@ -26,21 +26,35 @@ class MultiStackRootController(
         if (startPosition >= tabItems.size) throw IllegalStateException("Setup error: Position must be less than tab items count")
         _tabItems.clear()
         _tabItems.addAll(tabItems)
-        _stackChangeObserver.value = tabItems[startPosition]
+        updateTab(tabItems[startPosition])
     }
 
     @Deprecated("Use switchTab with position instead")
     fun switchTab(tabNavigationModel: TabNavigationModel) {
-        _stackChangeObserver.value = tabNavigationModel
+        updateTab(tabNavigationModel)
     }
 
     fun switchTab(position: Int) {
         if (position >= _tabItems.size) throw IllegalStateException("Position must be less than tab items count")
-        _stackChangeObserver.value = _tabItems[position]
+        updateTab(_tabItems[position])
     }
 
     override fun popBackStack() {
         val rootController = _stackChangeObserver.value?.rootController
         rootController?.popBackStack()
+    }
+
+    private fun updateTab(tabModel: TabNavigationModel) {
+        val screenKey = tabModel.rootController
+            .parentRootController // multistack controller
+            ?.parentRootController // actual parent controller
+            ?.currentScreen?.value // current transaction
+            ?.screen // owning screen
+            ?.realKey
+            ?.substringAfter('$')
+        val tabName = tabModel.tabInfo.tabItem.name// + " @@@ " + tabItem.tabInfo.tabItem.configuration.title)
+        val breadcrumb = if (screenKey != null) "$screenKey>$tabName" else tabName
+        onBreadcrumb(breadcrumb)
+        _stackChangeObserver.value = tabModel
     }
 }


### PR DESCRIPTION
I'm working on adding tracing and performance analytics to the app. Right now Odyssey provides one way to monitor transactions. `RootController.currentScreen` outputs updates related to shown and removed screens. Unfortunately, this flow doesn't emit stream of events which correspond to screen changes one-to-one.

This PR adds new callback which can be used by the app to monitor screen changes. It filters some event sources and helps with nested navigation (e.g. bottom navigation tabs switching emits both tab name and owner screen name).

Unfortunately, this doesn't cover multiple layers of nesting (like bottom navigation where the screen also has tabs). Also, I'm not 100% sure on the format of the data.

Could you please check the general direction of this change? Are there any caveats I should know, or maybe you have some different takes on solving this?