### PR TITLE
 the screamer remains on the screen for the duration of the animation when closing with a swipe

### DIFF
--- a/odyssey/odyssey-compose/src/commonMain/kotlin/ru/alexgladkov/odyssey/compose/navigation/modal_navigation/views/BottomSheetModalView.kt
+++ b/odyssey/odyssey-compose/src/commonMain/kotlin/ru/alexgladkov/odyssey/compose/navigation/modal_navigation/views/BottomSheetModalView.kt
@@ -96,7 +96,7 @@ internal fun BoxScope.BottomModalSheet(
 
     LaunchedEffect(bundle.dialogState, swipeableState.offset.value) {
         if (swipeableState.offset.value == viewHeight && bundle.dialogState !is ModalDialogState.Close) {
-            modalController.setTopDialogState(ModalDialogState.Close(), bundle.key)
+            modalController.setTopDialogState(ModalDialogState.Close(animate = false), bundle.key)
         }
 
         when (bundle.dialogState) {


### PR DESCRIPTION
При закрытии модалки свайпом скример отображается на время анимации и не даёт взаимодействовать с контентом